### PR TITLE
ENH: Base docker image set to Ubuntu 16.04

### DIFF
--- a/dream3d/Dockerfile
+++ b/dream3d/Dockerfile
@@ -1,10 +1,10 @@
-FROM dream3d/sdk:latest
+FROM dream3d/sdk-ubuntu-16.04:latest
 MAINTAINER DREAM3D Community
 
 RUN mkdir /usr/src/DREAM3D
 WORKDIR /usr/src/DREAM3D
 
-ENV DREAM3D_VERSION 1376dcc36b52ca105072cd8fb48183d95227a4bf
+ENV DREAM3D_VERSION b56ab529e19c4997019d11e193c66e6de48be38d
 RUN git clone https://github.com/BlueQuartzSoftware/DREAM3D.git && \
   cd DREAM3D && \
   git checkout ${DREAM3D_VERSION}
@@ -14,23 +14,26 @@ RUN git clone https://github.com/BlueQuartzSoftware/CMP.git && \
   cd CMP && \
   git checkout ${CMP_VERSION}
 
-ENV SIMPL_VERSION 4341309dfcc2219637f16bfd50faa1ad5b04b552
+ENV SIMPL_VERSION 1e796d25bd2c6526d3b618dc85459f16e60033f0
 RUN git clone https://github.com/BlueQuartzSoftware/SIMPL.git && \
   cd SIMPL && \
   git checkout ${SIMPL_VERSION}
 
-ENV SIMPLView_VERSION 3c5e4ca5c3b2bd38bb216759f414de42e0dd6546
+ENV SIMPLView_VERSION 4532c23df1fedd84d2edfe46d809b9b401c55e2f
 RUN git clone https://github.com/BlueQuartzSoftware/SIMPLView.git && \
   cd SIMPLView && \
   git checkout ${SIMPLView_VERSION}
 
-ENV CXXFLAGS="-std=c++11"
+ENV CXXFLAGS="-std=c++11 -Wall"
+ENV CC="/usr/bin/clang"
+ENV CXX="/usr/bin/clang++"
 
 RUN mkdir DREAM3D-build-Release && \
   cd DREAM3D-build-Release && \
   cmake -C /usr/src/DREAM3D_SDK/DREAM3D_SDK.cmake \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
+    -DTBB_ARCH_PLATFORM:PATH=x86_64-linux-gnu \
     ../DREAM3D && \
   ninja
 

--- a/dream3d/build.sh
+++ b/dream3d/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t dream3d/dream3d $script_dir
+docker build -t dream3d/dream3d-ubuntu-16.04 $script_dir

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM thewtex/opengl:latest
+FROM ubuntu:latest
 MAINTAINER DREAM3D Community
 
 RUN apt-get update && \
@@ -22,7 +22,6 @@ RUN apt-get update && \
   libcups2-dev \
   libdrm-dev \
   libegl1-mesa-dev \
-  libeigen3-dev \
   libevent-dev \
   libfftw3-dev \
   libflac-dev \
@@ -61,8 +60,10 @@ RUN apt-get update && \
   libxtst-dev \
   ninja-build \
   python-dev \
+  libdbus-1-dev \
   ruby \
   vim \
+  clang \
   wget
 
 WORKDIR /usr/src
@@ -83,19 +84,32 @@ RUN git clone git://cmake.org/cmake.git CMake && \
   cd .. && \
   rm -rf CMake*
 
-RUN wget http://download.qt.io/official_releases/qt/5.6/5.6.0/single/qt-everywhere-opensource-src-5.6.0.tar.gz && \
-  tar -xzf qt-everywhere-opensource-src-5.6.0.tar.gz && \
-  rm qt-everywhere-opensource-src-5.6.0.tar.gz && \
-  cd qt-everywhere-opensource-src-5.6.0 && \
+RUN wget --content-disposition http://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz && \
+  tar -xzf eigen-eigen-dc6cfdf9bcec.tar.gz && \
+  mkdir eigen3-build && \
+  cd eigen3-build && \
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    ../eigen-eigen-dc6cfdf9bcec/ && \
+  make && \
+  make install && \
+  cd .. && rm -rf eigen*
+
+RUN wget http://download.qt.io/official_releases/qt/5.6/5.6.1/single/qt-everywhere-opensource-src-5.6.1.tar.gz && \
+  tar -xzf qt-everywhere-opensource-src-5.6.1.tar.gz && \
+  rm qt-everywhere-opensource-src-5.6.1.tar.gz && \
+  cd qt-everywhere-opensource-src-5.6.1 && \
   ./configure \
     -opensource -confirm-license \
     -prefix /usr/src/DREAM3D_SDK/prefix-Release \
-    -no-compile-examples \
+    -nomake examples \
     -icu -openssl -qt-xcb -opengl -gui -widgets \
     -release && \
   make -j$(nproc) && \
   make install && \
   cd .. && rm -rf qt-everywhere-opensource*
+
 
 RUN wget --content-disposition https://sourceforge.net/projects/qwt/files/qwt/6.1.2/qwt-6.1.2.tar.bz2/download && \
   tar -xjf qwt-6.1.2.tar.bz2 && \
@@ -142,6 +156,7 @@ RUN wget --content-disposition https://sourceforge.net/projects/itk/files/itk/4.
   ninja && \
   ninja install && \
   cd .. && rm -rf InsightToolkit*
+
 
 ADD DREAM3D_SDK.cmake /usr/src/DREAM3D_SDK/
 VOLUME /usr/src/DREAM3D_SDK

--- a/sdk/build.sh
+++ b/sdk/build.sh
@@ -2,4 +2,4 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
-docker build -t dream3d/sdk $script_dir
+docker build -t dream3d/sdk-ubuntu-16.04 $script_dir


### PR DESCRIPTION
Using Ubuntu 16.04 allows to use clang 3.8 and gcc 5.4
The resulting docker images are much larger than the original ones. This should be kept as a branch to test the compilation of DREAM3D with newer compilers.