### PR TITLE
BUG: Missing SCIFIO environment variable

### DIFF
--- a/dream3d/Dockerfile
+++ b/dream3d/Dockerfile
@@ -25,6 +25,8 @@ RUN git clone https://github.com/BlueQuartzSoftware/SIMPLView.git && \
   git checkout ${SIMPLView_VERSION}
 
 ENV CXXFLAGS="-std=c++11"
+ENV SCIFIO_PATH=/usr/src/DREAM3D_SDK/prefix-Release/lib/jars/
+ENV JAVA_HOME=/usr/src/DREAM3D_SDK/prefix-Release/lib/jre/jre/
 
 RUN mkdir DREAM3D-build-Release && \
   cd DREAM3D-build-Release && \

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -143,5 +143,7 @@ RUN wget --content-disposition https://sourceforge.net/projects/itk/files/itk/4.
   ninja install && \
   cd .. && rm -rf InsightToolkit*
 
+RUN chmod +x /usr/src/DREAM3D_SDK/prefix-Release/lib/jre/jre/bin/java
+
 ADD DREAM3D_SDK.cmake /usr/src/DREAM3D_SDK/
 VOLUME /usr/src/DREAM3D_SDK


### PR DESCRIPTION
SCIFIO searches for bioformats_package.jar and scifio-itk-bridge.jar
in SCIFIO_PATH, the ITK build directory, and in /usr/local/lib/jar.
ITK build directory is removed from the docker image, and ITK jar
packages are installed in /usr/src/DREAM3D_SDK/prefix-Release/lib/jars/.