### PR TITLE
BUG: UpdateDockerfile.sh was only usable from dream3d sub-folder

### DIFF
--- a/dream3d/UpdateDockerfile.sh
+++ b/dream3d/UpdateDockerfile.sh
@@ -7,18 +7,18 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 sha=`git ls-remote https://github.com/BlueQuartzSoftware/DREAM3D.git| grep HEAD | awk '{ print $1}'`
 echo "New DREAM3D SHA: $sha"
-sed -i "s/ENV DREAM3D_VERSION.*$/ENV DREAM3D_VERSION $sha/" Dockerfile
+sed -i "s/ENV DREAM3D_VERSION.*$/ENV DREAM3D_VERSION $sha/" $DIR/Dockerfile
 
 sha=`git ls-remote https://github.com/BlueQuartzSoftware/CMP.git| grep HEAD | awk '{ print $1}'`
 echo "New CMP SHA: $sha"
-sed -i "s/ENV CMP_VERSION.*$/ENV CMP_VERSION $sha/" Dockerfile
+sed -i "s/ENV CMP_VERSION.*$/ENV CMP_VERSION $sha/" $DIR/Dockerfile
 
 sha=`git ls-remote https://github.com/BlueQuartzSoftware/SIMPL.git| grep HEAD | awk '{ print $1}'`
 echo "New SIMPL SHA: $sha"
-sed -i "s/ENV SIMPL_VERSION.*$/ENV SIMPL_VERSION $sha/" Dockerfile
+sed -i "s/ENV SIMPL_VERSION.*$/ENV SIMPL_VERSION $sha/" $DIR/Dockerfile
 
 sha=`git ls-remote https://github.com/BlueQuartzSoftware/SIMPLView.git| grep HEAD | awk '{ print $1}'`
 echo "New SIMPLView SHA: $sha"
-sed -i "s/ENV SIMPLView_VERSION.*$/ENV SIMPLView_VERSION $sha/" Dockerfile
+sed -i "s/ENV SIMPLView_VERSION.*$/ENV SIMPLView_VERSION $sha/" $DIR/Dockerfile
 
-git commit Dockerfile -m "ENH: Update DREAM.3D repos to $current_date develop branch."
+git commit $DIR/Dockerfile -m "ENH: Update DREAM.3D repos to $current_date develop branch."


### PR DESCRIPTION
The script UpdateDockerfile.sh was checking whad directory it
was running from but was not using that piece of information
to specify where the Dockerfile could be found. Therefore,
the script could only be run from the Dream3D subfolder, and
not from any location.