### PR TITLE
ENH: Verifies if git branch already exists

### DIFF
--- a/dream3d/UpdateDockerfile.sh
+++ b/dream3d/UpdateDockerfile.sh
@@ -2,6 +2,12 @@
 
 current_date=`date +%Y-%m-%d`
 git checkout -b update_DREAM3D_$current_date
+res="$?"
+if [ "$res" -ne "0" ]
+then
+  echo "branch already exist. Remove it if necessary."
+  exit -1
+fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
Script verifies if the new branch created for git already
exists. If it exists, it prints an error message and exists.
Previously, the commit would be performed on the current branch
(often master) which would not be the desired behavior.